### PR TITLE
chore: API changes from dependency version bumps plus cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ For more information about importing things in Javascript, please refer to [impo
 
 1. #### `MermaidWrapper` component
 
+   Starlight does not support Mermaid by default, so you would have to install [remark-mermaidjs](https://github.com/remcohaszing/remark-mermaidjs) on your Starlight site before you can use this component.
+
    Use this component if your Mermaid diagram is much larger than our available space and you would like users to view the full diagram in another tab. This adds "View full diagram" button with an external link indicator on the bottom right corner under the diagram. Note that the `client:load` attribute is required for the functionality to work because this component relies on state.
 
    To use it, your docs page must be in `.mdx` format. Please change the format from `.md` to `.mdx` if necessary. All your existing markdown will still be supported without issue. Import the `MermaidWrapper` component like so:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {
@@ -15,6 +15,10 @@
   },
   "author": "Interledger <tech@interledger.org>",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/interledger/docs-design-system"
+  },
   "dependencies": {
     "react": "^18.2.0"
   }

--- a/src/components/Dinosaur.astro
+++ b/src/components/Dinosaur.astro
@@ -1,3 +1,0 @@
----
----
-<button>Rawr</button>

--- a/src/components/SidebarToggle/SidebarToggle.css
+++ b/src/components/SidebarToggle/SidebarToggle.css
@@ -1,3 +1,0 @@
-.button {
-  background: transparent;
-}

--- a/src/components/SidebarToggle/SidebarToggle.jsx
+++ b/src/components/SidebarToggle/SidebarToggle.jsx
@@ -1,5 +1,0 @@
-import styles from "./SidebarToggle.module.css";
-
-export default function SidebarToggle() {
-  return <button className={styles.button}>Click</button>;
-}

--- a/src/components/SidebarToggle/index.js
+++ b/src/components/SidebarToggle/index.js
@@ -1,3 +1,0 @@
-import SidebarToggle from "./SidebarToggle.jsx";
-
-export default SidebarToggle;

--- a/src/styles/ilf-docs.css
+++ b/src/styles/ilf-docs.css
@@ -435,7 +435,6 @@ input:not([type="submit"]):not([type="file"]):focus {
 }
 
 /* Misc tweaks and overrides */
-
 .content astro-island > button[aria-expanded="false"] + div {
   margin-top: 0;
 }
@@ -445,7 +444,7 @@ input:not([type="submit"]):not([type="file"]):focus {
 }
 
 /* MathJax styles */
-.math-inline {
+.MathJax {
   display: inline-block;
   vertical-align: middle;
 }


### PR DESCRIPTION
This PR updates the class name for mathjax markup after the rehype plugin version bump and removes some test files that were accidentally committed the first time around.