### PR TITLE
chore: resolve diagram background on dark mode issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {

--- a/src/styles/ilf-docs.css
+++ b/src/styles/ilf-docs.css
@@ -290,6 +290,13 @@ code {
   border: 1px solid var(--sl-color-hairline-light);
 }
 
+[aria-roledescription="sequence"] {
+  background-color: white;
+  border-radius: var(--border-radius);
+  box-shadow: var(--sl-shadow-sm);
+  border: 1px solid var(--sl-color-hairline-light);
+}
+
 /* Aside style overrides */
 aside.starlight-aside {
   padding: var(--space-xs) var(--space-s);


### PR DESCRIPTION
This PR adds the CSS to make mermaid diagram backgrounds white such that they should up on a dark background.