### PR TITLE
feat: update the CodeBlock component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -17,6 +17,10 @@ div {
   margin-top: 0;
 }
 
+.codeblock :global(.expressive-code) {
+  margin-top: 0;
+}
+
 p {
   margin-top: var(--space-s);
   border-top-right-radius: var(--border-radius);

--- a/src/styles/ilf-docs.css
+++ b/src/styles/ilf-docs.css
@@ -281,7 +281,8 @@
 table,
 pre,
 .starlight-aside,
-.img-outline {
+.img-outline,
+.expressive-code {
   border-radius: var(--border-radius);
   box-shadow: var(--sl-shadow-sm);
 }


### PR DESCRIPTION
Closes https://github.com/interledger/docs-styleguide/issues/2

Starlight 0.13.0 finally shipped their expressive code integration (see https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.13.0), there are some styling changes that need to be made to our current CodeBlock component so everything still looks right.