### PR TITLE
fix: make mermaid path absolute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "https://github.com/interledger/docs-design-system"
   },
-  "devDependencies": {
+  "dependencies": {
     "mermaid": "^10.6.1"
   }
 }

--- a/src/components/Mermaid.astro
+++ b/src/components/Mermaid.astro
@@ -9,6 +9,6 @@ const { graph } = Astro.props;
 <pre class="mermaid" set:html={graph} />
 
 <script>
-  import mermaid from "../../node_modules/mermaid/dist/mermaid.esm.min.mjs";
+  import mermaid from "/node_modules/mermaid/dist/mermaid.esm.min.mjs";
   mermaid.initialize({ startOnLoad: true });
 </script>


### PR DESCRIPTION
This PR fixes a build issue when the mermaid dependency used a relative path to the node_modules folder.