### PR TITLE
chore: bump dependencies and bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {
@@ -20,6 +20,6 @@
     "url": "https://github.com/interledger/docs-design-system"
   },
   "dependencies": {
-    "mermaid": "^10.8.0"
+    "mermaid": "^10.9.0"
   }
 }

--- a/src/components/StylishHeader.astro
+++ b/src/components/StylishHeader.astro
@@ -13,7 +13,7 @@
   }
 
   p::after {
-    background-color: var(--color-accent-secondary);
+    background-color: var(--color-accent-highlight);
     height: 8px;
     bottom: 4px;
     z-index: -1;

--- a/src/styles/ilf-docs.css
+++ b/src/styles/ilf-docs.css
@@ -200,7 +200,7 @@
 
   nav.sidebar .sidebar-pane {
     position: sticky;
-    height: 100vh;
+    height: calc(100vh - var(--sl-nav-height));
   }
 
   div.main-frame {
@@ -295,7 +295,7 @@ code {
   border: 1px solid var(--sl-color-hairline-light);
 }
 
-[aria-roledescription="sequence"] {
+.mermaid > svg {
   background-color: white;
   border-radius: var(--border-radius);
 }


### PR DESCRIPTION
This PR bumps Mermaid to the latest version, and fixes:
1. mermaid diagrams such that all generated SVG have a white background
2. the sidebar being hidden under the header at wide widths and the active link is on the lower part of the sidebar