### PR TITLE
chore: bump dependencies to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/interledger/docs-design-system"
   },
   "dependencies": {
-    "mermaid": "^10.9.1"
+    "mermaid": "^11.4.0"
   }
 }


### PR DESCRIPTION
This PR bumps mermaid to the latest version.
Tested with the styleguide repo and no issues found there.