### PR TITLE
Bump dependencies and version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {
@@ -20,6 +20,6 @@
     "url": "https://github.com/interledger/docs-design-system"
   },
   "dependencies": {
-    "mermaid": "^11.4.0"
+    "mermaid": "^11.4.1"
   }
 }

--- a/src/components/StylishHeader.astro
+++ b/src/components/StylishHeader.astro
@@ -6,7 +6,7 @@
 @media screen and (min-width: 500px) {
   p {
     display: inline-block;
-    font-weight: bold;
+    font-weight: 600;
     position: relative;
     color: var(--sl-color-white);
     font-size: var(--step-1);


### PR DESCRIPTION
This PR bumps the Mermaid dependency to 11.4.1 and fixes a styling issue with the StylishHeader component.