### PR TITLE
fix: remove unnecessary id attribute from codeblock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -1,7 +1,7 @@
 ---
-const { title, id, class: className } = Astro.props;
+const { title, class: className } = Astro.props;
 ---
-<div class:list={['codeblock', className]} id={id}>
+<div class:list={['codeblock', className]}>
   <p>{title}</p>
   <slot />
 </div>


### PR DESCRIPTION
This PR removes an unnecessary ID attribute from the CodeBlock component