### PR TITLE
fix the extra <p> in the linkout component

### DIFF
--- a/src/components/LinkOut.astro
+++ b/src/components/LinkOut.astro
@@ -10,10 +10,6 @@ slotContent = slotContent.replace(/^<p>(.*)<\/p>$/s, '$1').trim()
 >
 
 <style>
-  .link-out {
-    display: inline;
-  }
-
   .icon {
     display: inline-block;
     margin-left: var(--space-3xs);


### PR DESCRIPTION
test this out by looking at a multi line <linkout component

<img width="668" height="137" alt="image" src="https://github.com/user-attachments/assets/2dc4b43d-13d2-484d-ba0c-302d74987149" />
<img width="222" height="73" alt="image" src="https://github.com/user-attachments/assets/ba516162-2732-486e-99e4-2775fd215e0e" />
