### PR TITLE
fix(styles): scope form element selectors to .sl-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interledger/docs-design-system",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "description": "Shared styles and components used across all Interledger Starlight documentation sites",
   "exports": {

--- a/src/styles/ilf-docs.css
+++ b/src/styles/ilf-docs.css
@@ -488,12 +488,12 @@ pre.astro-code {
   border: 0;
 }
 
-/* Input styles */
-label {
+/* Input styles — scoped to .sl-container to prevent leaking to non-Starlight pages */
+.sl-container label {
   font-size: var(--sl-text-body-sm);
 }
 
-input:not([type='submit']):not([type='file']):not(.pagefind-ui__search-input) {
+.sl-container input:not([type='submit']):not([type='file']):not(.pagefind-ui__search-input) {
   border: 1px solid var(--sl-color-accent);
   padding: var(--space-3xs) var(--space-2xs);
   border-radius: var(--border-radius);
@@ -501,11 +501,11 @@ input:not([type='submit']):not([type='file']):not(.pagefind-ui__search-input) {
   font-size: var(--sl-text-body);
 }
 
-input:not([type='submit']):not([type='file']):focus {
+.sl-container input:not([type='submit']):not([type='file']):focus {
   background-color: var(--sl-color-accent-low);
 }
 
-::placeholder {
+.sl-container ::placeholder {
   color: var(--sl-color-accent-high);
   opacity: 0.6;
 }


### PR DESCRIPTION
## Summary

- Scoped `label`, `input:not(...)`, `input:focus`, and `::placeholder` selectors to `.sl-container`
- These were unscoped and leaking Starlight form styles (border, padding, margin, font-size) onto non-Starlight pages
- Same pattern as the h3 fix in #68

## Context

`interledger.org-v5` mixes Starlight doc pages with non-Starlight pages. The unscoped form selectors in `ilf-docs.css` applied globally, causing the contact form and other non-doc pages to inherit Starlight's accent border, spacing, and font sizing.

Resolves INTORG-529

## Test plan

- [ ] Verify form inputs on Starlight doc pages still have correct styling
- [ ] Verify non-Starlight pages (e.g., /contact) no longer inherit Starlight form styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)